### PR TITLE
Fixed bug causing seeds to not be saved

### DIFF
--- a/presp/evolution.py
+++ b/presp/evolution.py
@@ -182,8 +182,10 @@ class Evolution:
         for candidate in self.population:
             # Save to file if it's new. Only save rank 1 candidates if save_all is False.
             cand_gen = int(candidate.cand_id.split("_")[0])
-            if (candidate.rank == 1 or self.save_all) and cand_gen == self.generation:
-                self.save_cache.append(candidate)
+            if candidate.rank == 1 or self.save_all:
+                # If the candidate is new (edge case for seeds in generation 0 which must be manually accounted for)
+                if cand_gen == self.generation or (cand_gen == 0 and self.generation == 1):
+                    self.save_cache.append(candidate)
             # Record candidates' results
             row = {
                 "gen": self.generation,


### PR DESCRIPTION
Hard-coded in edge case where seeds weren't being saved. Since the seeds' generation never appears as we start at 1, we just check if there are any candidates with generation 0 while we are saving generation 1's candidates.